### PR TITLE
Test and funcionality to delete course

### DIFF
--- a/sprint-5/app/Http/Controllers/Admin/CourseController.php
+++ b/sprint-5/app/Http/Controllers/Admin/CourseController.php
@@ -14,4 +14,10 @@ class CourseController extends Controller
         $course = Course::create($request->validated());
         return response()->json($course, 201);
     }
+
+    public function destroy(Course $course)
+    {
+        $course->delete();
+        return response()->json(['message' => 'Course deleted successfully'], 200);
+    }
 }

--- a/sprint-5/database/seeders/RolesAndPermissionsSeeder.php
+++ b/sprint-5/database/seeders/RolesAndPermissionsSeeder.php
@@ -23,10 +23,11 @@ class RolesAndPermissionsSeeder extends Seeder
         $unenrollCoursePermission = Permission::firstOrCreate(['name' => 'unenroll-course', 'guard_name' => 'api']);
         $viewUserInfoPermission = Permission::firstOrCreate(['name' => 'view-user-info', 'guard_name' => 'api']);
         $getAllUsersPermission = Permission::firstOrCreate(['name' => 'get-all-users', 'guard_name' => 'api']);
+        $deleteCoursePermission = Permission::firstOrCreate(['name' => 'delete-course', 'guard_name' => 'api']);
 
 
         $userRole->givePermissionTo($deleteAccountPermission, $enrollCoursePermission, $unenrollCoursePermission, $viewUserInfoPermission);
 
-        $adminRole->givePermissionTo($createCoursePermission, $viewUserInfoPermission, $getAllUsersPermission);
+        $adminRole->givePermissionTo($createCoursePermission, $viewUserInfoPermission, $getAllUsersPermission, $deleteCoursePermission);
     }
 }

--- a/sprint-5/routes/api.php
+++ b/sprint-5/routes/api.php
@@ -33,6 +33,8 @@ Route::middleware('auth:api')->group(function () {
             ->post('/courses', [CourseController::class, 'store']);
         Route::middleware('permission:get-all-users')
             ->get('/users', [UserController::class, 'index']);
+        Route::middleware('permission:delete-course')
+            ->delete('/courses/{course}', [CourseController::class, 'destroy']);
     });
 });
 

--- a/sprint-5/tests/Feature/Course/Success/DeleteCourseTest.php
+++ b/sprint-5/tests/Feature/Course/Success/DeleteCourseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Course\Success;
+
+use App\Models\Course;
+use App\Models\User;
+use Tests\ApiTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class DeleteCourseTest extends ApiTestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_delete_course()
+    {
+        $this->withoutExceptionHandling();
+
+        $admin = User::factory()->create();
+        $course = Course::factory()->create();
+
+        $token = $admin->createToken('admin-token')->accessToken;
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->deleteJson('/api/courses/' . $course->id);
+
+        $response->assertStatus(200);
+        
+        $response->assertJson([
+            'message' => 'Course deleted successfully',
+        ]);
+        $this->assertDatabaseMissing('courses', [
+            'id' => $course->id,
+        ]);
+    }
+}

--- a/sprint-5/tests/Feature/Course/Success/DeleteCourseTest.php
+++ b/sprint-5/tests/Feature/Course/Success/DeleteCourseTest.php
@@ -16,6 +16,7 @@ class DeleteCourseTest extends ApiTestCase
         $this->withoutExceptionHandling();
 
         $admin = User::factory()->create();
+        $admin->assignRole('admin');
         $course = Course::factory()->create();
 
         $token = $admin->createToken('admin-token')->accessToken;
@@ -25,7 +26,7 @@ class DeleteCourseTest extends ApiTestCase
         ])->deleteJson('/api/courses/' . $course->id);
 
         $response->assertStatus(200);
-        
+
         $response->assertJson([
             'message' => 'Course deleted successfully',
         ]);

--- a/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
+++ b/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Course\Validation;
 
 use App\Models\Course;
+use App\Models\User;
 use Tests\ApiTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -14,6 +15,9 @@ class DeleteCourseFailTest extends ApiTestCase
     {
         //$this->withoutExceptionHandling();
 
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
         $course = Course::factory()->create();
 
         $response = $this->deleteJson('/api/courses/' . $course->id);
@@ -22,5 +26,26 @@ class DeleteCourseFailTest extends ApiTestCase
         $response->assertJson([
             'message' => 'Unauthenticated.',
         ]);
+    }
+
+    public function test_admin_cannot_delete_course_with_invalid_token()
+    {
+        //$this->withoutExceptionHandling();
+
+        $course = Course::factory()->create();
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+        $token = "Invalid token";
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->deleteJson('/api/courses/' . $course->id);
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'message' => 'Unauthenticated.',
+        ]);
+
+
     }
 }

--- a/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
+++ b/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
@@ -60,5 +60,21 @@ class DeleteCourseFailTest extends ApiTestCase
     
         $response->assertStatus(404);
     }
+
+    public function test_user_cannot_delete_course()
+    {
+        //$this->withoutExceptionHandling();
+
+        $user = User::factory()->create();
+        $user->assignRole('user');
+        $course = Course::factory()->create();
+        $token = $user->createToken('user-token')->accessToken;
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->deleteJson('/api/courses/' . $course->id);
+
+        $response->assertStatus(403);
+    }
     
 }

--- a/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
+++ b/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\Course\Validation;
+
+use App\Models\Course;
+use Tests\ApiTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class DeleteCourseFailTest extends ApiTestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_cannot_delete_course_without_token()
+    {
+        //$this->withoutExceptionHandling();
+
+        $course = Course::factory()->create();
+
+        $response = $this->deleteJson('/api/courses/' . $course->id);
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'message' => 'Unauthenticated.',
+        ]);
+    }
+}

--- a/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
+++ b/sprint-5/tests/Feature/Course/Validation/DeleteCourseFailTest.php
@@ -45,7 +45,20 @@ class DeleteCourseFailTest extends ApiTestCase
         $response->assertJson([
             'message' => 'Unauthenticated.',
         ]);
-
-
     }
+
+    public function test_admin_cannot_delete_inexistent_course()
+    {
+        $admin = User::factory()->create();
+        $course = Course::factory()->create();
+        $admin->assignRole('admin');
+        $token = $admin->createToken('admin-token')->accessToken;
+        
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->deleteJson('/api/courses/' . $course->id + 1);
+    
+        $response->assertStatus(404);
+    }
+    
 }


### PR DESCRIPTION
In this PR are implemented the test and funcionalities to get a delete a course

Tests:

Success:
- test_admin_can_delete_course

Fail:
- est_admin_cannot_delete_course_without_token
- test_admin_cannot_delete_course_with_invalid_token
- test_admin_cannot_delete_inexistent_course
- test_user_cannot_delete_course

- Methods:

method destroy in CourseController
